### PR TITLE
점포 등록 검증 로직 추가

### DIFF
--- a/src/main/java/com/dongyang/dongpo/controller/location/LocationController.java
+++ b/src/main/java/com/dongyang/dongpo/controller/location/LocationController.java
@@ -26,9 +26,9 @@ public class LocationController {
         return ResponseEntity.ok(new ApiResponse<>(locationService.getDistance(latLongComparison)));
     }
 
-    @PostMapping("/verify")
-    public ResponseEntity<ApiResponse<Boolean>> verifyCoordinate(@RequestBody LatLongComparisonDto latLongComparison) {
-        return (locationService.verifyCoordinate(latLongComparison)
+    @PostMapping("/verify") // 방문 인증 기능
+    public ResponseEntity<ApiResponse<Boolean>> verifyVisitCert(@RequestBody LatLongComparisonDto latLongComparison) {
+        return (locationService.verifyVisitCert(latLongComparison)
                 ? ResponseEntity.ok(new ApiResponse<>(true))
                 : ResponseEntity.ok(new ApiResponse<>(false)));
     }

--- a/src/main/java/com/dongyang/dongpo/controller/store/StoreController.java
+++ b/src/main/java/com/dongyang/dongpo/controller/store/StoreController.java
@@ -4,6 +4,7 @@ import com.dongyang.dongpo.apiresponse.ApiResponse;
 import com.dongyang.dongpo.domain.member.Member;
 import com.dongyang.dongpo.dto.location.LatLong;
 import com.dongyang.dongpo.dto.store.StoreDto;
+import com.dongyang.dongpo.dto.store.StoreRegisterDto;
 import com.dongyang.dongpo.service.store.StoreService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class StoreController {
 
     @PostMapping("")
     @Operation(summary = "점포 등록")
-    public ResponseEntity<ApiResponse<String>> addStore(@RequestBody StoreDto request,
+    public ResponseEntity<ApiResponse<String>> addStore(@RequestBody StoreRegisterDto request,
                                                         @AuthenticationPrincipal Member member) {
         storeService.addStore(request, member);
         return ResponseEntity.ok(new ApiResponse<>("success"));

--- a/src/main/java/com/dongyang/dongpo/dto/store/StoreRegisterDto.java
+++ b/src/main/java/com/dongyang/dongpo/dto/store/StoreRegisterDto.java
@@ -1,0 +1,51 @@
+package com.dongyang.dongpo.dto.store;
+
+import com.dongyang.dongpo.domain.member.Member;
+import com.dongyang.dongpo.domain.store.OperatingDay;
+import com.dongyang.dongpo.domain.store.PayMethod;
+import com.dongyang.dongpo.domain.store.Store;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StoreRegisterDto {
+
+    private String name;
+    private String address;
+    private double latitude;
+    private double longitude;
+    private LocalTime openTime;
+    private LocalTime closeTime;
+    private boolean isToiletValid;
+    private List<OperatingDay> operatingDays;
+    private List<PayMethod> payMethods;
+
+    // 등록하는 사용자의 현재 좌표
+    private double currentLatitude;
+    private double currentLongitude;
+
+    public Store toStore(Member member){
+        return Store.builder()
+                .name(name)
+                .address(address)
+                .latitude(latitude)
+                .longitude(longitude)
+                .openTime(openTime)
+                .closeTime(closeTime)
+                .member(member)
+                .isToiletValid(isToiletValid)
+                .operatingDays(operatingDays)
+                .payMethods(payMethods)
+                .build();
+    }
+}

--- a/src/main/java/com/dongyang/dongpo/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/dongyang/dongpo/exception/CustomControllerAdvice.java
@@ -7,6 +7,7 @@ import com.dongyang.dongpo.exception.data.DataNotFoundException;
 import com.dongyang.dongpo.exception.member.MemberNotFoundException;
 import com.dongyang.dongpo.exception.social.SocialTokenNotValidException;
 import com.dongyang.dongpo.exception.store.StoreNotFoundException;
+import com.dongyang.dongpo.exception.store.StoreRegistrationNotValidException;
 import com.dongyang.dongpo.jwt.exception.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -88,6 +89,12 @@ public class CustomControllerAdvice {
     @ExceptionHandler(ArgumentNotSatisfiedException.class)
     public ResponseEntity<ApiResponse<String>> handleArgumentNotSatisfiedException() {
         response.setMessage("요청이 잘못되었습니다.");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(StoreRegistrationNotValidException.class)
+    public ResponseEntity<ApiResponse<String>> handleStoreRegistrationNotValidException() {
+        response.setMessage("위치 정보가 오차를 벗어났습니다.");
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 

--- a/src/main/java/com/dongyang/dongpo/exception/store/StoreRegistrationNotValidException.java
+++ b/src/main/java/com/dongyang/dongpo/exception/store/StoreRegistrationNotValidException.java
@@ -1,0 +1,7 @@
+package com.dongyang.dongpo.exception.store;
+
+public class StoreRegistrationNotValidException extends RuntimeException {
+    public StoreRegistrationNotValidException() {
+        super();
+    }
+}

--- a/src/main/java/com/dongyang/dongpo/service/location/LocationService.java
+++ b/src/main/java/com/dongyang/dongpo/service/location/LocationService.java
@@ -4,6 +4,7 @@ import com.dongyang.dongpo.domain.store.Store;
 import com.dongyang.dongpo.dto.location.LatLong;
 import com.dongyang.dongpo.dto.location.LatLongComparisonDto;
 import com.dongyang.dongpo.dto.location.CoordinateRange;
+import com.dongyang.dongpo.dto.store.StoreRegisterDto;
 import com.dongyang.dongpo.exception.data.DataNotFoundException;
 import com.dongyang.dongpo.repository.store.StoreRepository;
 import jakarta.transaction.Transactional;
@@ -55,8 +56,8 @@ public class LocationService {
         return calcDistance(newCoordinate, getStoreCoordinates(latLongComparison.getTargetStoreId()));
     }
 
-    // 신규 좌표가 기존 좌표의 오차범위 내에 위치하는지 검증
-    public Boolean verifyCoordinate(LatLongComparisonDto latLongComparison) {
+    // 신규 좌표가 기존 좌표의 오차범위 내에 위치하는지 검증 (방문 인증 검증)
+    public Boolean verifyVisitCert(LatLongComparisonDto latLongComparison) {
         LatLong newCoordinate = LatLong.builder()
                 .latitude(latLongComparison.getLatitude())
                 .longitude(latLongComparison.getLongitude())
@@ -79,5 +80,23 @@ public class LocationService {
                 .minLong(latLong.getLongitude() - deltaLong)
                 .maxLong(latLong.getLongitude() + deltaLong)
                 .build();
+    }
+
+    // 점포 등록 시 좌표 검증
+    public Boolean verifyStoreRegistration(StoreRegisterDto request) {
+        // 등록 하고자 하는 점포의 좌표
+        LatLong storeCord =  LatLong.builder()
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .build();
+
+        // 사용자의 현재 좌표
+        LatLong userCord =  LatLong.builder()
+                .latitude(request.getCurrentLatitude())
+                .longitude(request.getCurrentLongitude())
+                .build();
+
+        // 오차가 100m 이내일 경우 true, 초과일 경우 false 반환
+        return calcDistance(userCord, storeCord) <= 100;
     }
 }

--- a/src/main/java/com/dongyang/dongpo/service/store/StoreService.java
+++ b/src/main/java/com/dongyang/dongpo/service/store/StoreService.java
@@ -7,8 +7,10 @@ import com.dongyang.dongpo.dto.location.CoordinateRange;
 import com.dongyang.dongpo.dto.location.LatLong;
 import com.dongyang.dongpo.dto.store.ReviewDto;
 import com.dongyang.dongpo.dto.store.StoreDto;
+import com.dongyang.dongpo.dto.store.StoreRegisterDto;
 import com.dongyang.dongpo.exception.member.MemberNotFoundException;
 import com.dongyang.dongpo.exception.store.StoreNotFoundException;
+import com.dongyang.dongpo.exception.store.StoreRegistrationNotValidException;
 import com.dongyang.dongpo.repository.store.StoreRepository;
 import com.dongyang.dongpo.service.location.LocationService;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +32,11 @@ public class StoreService {
 
 
     @Transactional
-    public void addStore(StoreDto request, Member member){
+    public void addStore(StoreRegisterDto request, Member member) {
+        // 사용자의 현재 위치와 점포 등록 위치가 범위 내에 있는지 검증
+        if (!locationService.verifyStoreRegistration(request))
+            throw new StoreRegistrationNotValidException();
+
         Store store = request.toStore(member);
         Store save = storeRepository.save(store);
 

--- a/src/test/java/com/dongyang/dongpo/service/location/LocationServiceTest.java
+++ b/src/test/java/com/dongyang/dongpo/service/location/LocationServiceTest.java
@@ -1,0 +1,75 @@
+package com.dongyang.dongpo.service.location;
+
+import com.dongyang.dongpo.dto.store.StoreRegisterDto;
+import com.dongyang.dongpo.repository.store.StoreRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class LocationServiceTest {
+
+    @InjectMocks
+    private LocationService locationService;
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Test
+    void calcDistance() {
+    }
+
+    @Test
+    void getDistance() {
+    }
+
+    @Test
+    void verifyVisitCert() {
+    }
+
+    @Test
+    void calcCoordinateRangeByCurrentLocation() {
+    }
+
+    @Test
+    void verifyStoreRegistration() {
+        // given
+        StoreRegisterDto storeDto = StoreRegisterDto.builder()
+                .name("테스트")
+                .address("서울시 구로구")
+                .latitude(37.49986174919337)
+                .longitude(126.86771368999942)
+                .currentLatitude(37.50289368559725)
+                .currentLongitude(126.88044271559237)
+                .build();
+
+        // when
+        Boolean result = locationService.verifyStoreRegistration(storeDto);
+
+        // then
+        assertFalse(result); // 100m 초과
+    }
+
+    @Test
+    void verifyStoreRegistrationWithinRange() {
+        // given
+        StoreRegisterDto storeDto = StoreRegisterDto.builder()
+                .name("테스트")
+                .address("서울시 구로구")
+                .latitude(37.50289368559725)
+                .longitude(126.88044271559237)
+                .currentLatitude(37.50289368559725)
+                .currentLongitude(126.88044271559237)
+                .build();
+
+        // when
+        Boolean result = locationService.verifyStoreRegistration(storeDto);
+
+        // then
+        assertTrue(result); // 100m 이내
+    }
+}

--- a/src/test/java/com/dongyang/dongpo/service/store/StoreServiceTest.java
+++ b/src/test/java/com/dongyang/dongpo/service/store/StoreServiceTest.java
@@ -3,7 +3,9 @@ package com.dongyang.dongpo.service.store;
 import com.dongyang.dongpo.domain.member.Member;
 import com.dongyang.dongpo.domain.store.Store;
 import com.dongyang.dongpo.dto.store.StoreDto;
+import com.dongyang.dongpo.dto.store.StoreRegisterDto;
 import com.dongyang.dongpo.repository.store.StoreRepository;
+import com.dongyang.dongpo.service.location.LocationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,16 +28,24 @@ class StoreServiceTest {
     @InjectMocks
     private StoreService storeService;
 
+    @Mock
+    private LocationService locationService;
+
     @Test
     @DisplayName("점포_등록")
     void addStore() {
-        StoreDto storeDto = mock(StoreDto.class);
+        // given
+        StoreRegisterDto storeDto = mock(StoreRegisterDto.class);
         Member member = mock(Member.class);
+        Store store = mock(Store.class);
 
-        when(storeRepository.save(any())).thenReturn(mock(Store.class));
+        when(locationService.verifyStoreRegistration(storeDto)).thenReturn(true);
+        when(storeRepository.save(any())).thenReturn(store);
 
+        // when
         storeService.addStore(storeDto, member);
 
+        // then
         verify(storeRepository).save(any());
     }
 


### PR DESCRIPTION
#33 #34 
- 점포의 위치와 현재 사용자의 위치가 오차 범위 내에 있는지 검증
- 점포 등록 위한 별도 DTO 추가
- 점포 등록, 범위 검증 테스트 케이스 작성
- 방문 인증 기능의 메소드 명 변경