### PR TITLE
토큰 인증 오류 해결

### DIFF
--- a/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
+++ b/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                 .authenticationProvider(nomalAuthenticationProvider())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/admin/**").denyAll()
-                        .requestMatchers("/api/**").permitAll()
+                        .requestMatchers("/api/**").authenticated()
+                        .requestMatchers("/auth/**").permitAll()
                         .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/dongyang/dongpo/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dongyang/dongpo/jwt/JwtTokenProvider.java
@@ -117,4 +117,8 @@ public class JwtTokenProvider {
             throw new RuntimeException(e);
         }
     }
+
+    public String parseAccessToken(String authorization) {
+        return authorization.substring(7);
+    }
 }


### PR DESCRIPTION
#39 
- JwtAuthenticationFilter의 토큰 검증 로직 수정
- 인증 정보가 없으면 다음 FilterChain으로 넘어가도록 함
- SecurityConfig 엔드포인트 접근 권한 수정