### PR TITLE
소셜 로그인 사용자 검증 로직 수정

### DIFF
--- a/src/main/java/com/dongyang/dongpo/repository/member/MemberRepository.java
+++ b/src/main/java/com/dongyang/dongpo/repository/member/MemberRepository.java
@@ -9,5 +9,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Boolean existsBySocialId(String socialId);
+
     Boolean existsByEmail(String email);
 }

--- a/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
+++ b/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
@@ -45,8 +45,9 @@ public class MemberService {
     public JwtToken socialSave(UserInfo userInfo){
         Member member = Member.toEntity(userInfo);
 
-        if (memberRepository.existsByEmail(member.getEmail()))
-            return tokenService.social_AlreadyExistMember(member);
+        // 이미 가입된 회원인 경우 로그인 처리
+        if (memberRepository.existsBySocialId(member.getSocialId()))
+            return tokenService.createTokenForLoginMember(member);
 
         memberRepository.save(member);
         memberTitleRepository.save(MemberTitle.builder()

--- a/src/main/java/com/dongyang/dongpo/service/token/TokenService.java
+++ b/src/main/java/com/dongyang/dongpo/service/token/TokenService.java
@@ -41,7 +41,7 @@ public class TokenService {
     }
 
     @Transactional
-    public JwtToken social_AlreadyExistMember(Member member){
+    public JwtToken createTokenForLoginMember(Member member){
         JwtToken jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole());
         RefreshToken refreshToken = refreshTokenRepository.findByEmail(member.getEmail()).orElse(null);
 
@@ -54,7 +54,7 @@ public class TokenService {
                     .build();
 
         refreshTokenRepository.save(refreshToken);
-        log.info("(Login) Refresh Token Reissued : {}", member.getEmail());
+        log.info("Member Login : {}", member.getEmail());
         return jwtToken;
     }
 }

--- a/src/test/java/com/dongyang/dongpo/service/token/TokenServiceTest.java
+++ b/src/test/java/com/dongyang/dongpo/service/token/TokenServiceTest.java
@@ -110,7 +110,7 @@ class TokenServiceTest {
 
     @Test
     @DisplayName("소셜 로그인 - 이미 존재하는 회원일 경우 토큰 발급")
-    void social_AlreadyExistMemberTest() {
+    void createTokenForLoginMember() {
         JwtToken mockJwtToken = mock(JwtToken.class);
 
         when(member.getEmail()).thenReturn("test@test.com");
@@ -122,7 +122,7 @@ class TokenServiceTest {
         when(mockJwtToken.getAccessToken()).thenReturn("mockAccessToken");
         when(mockJwtToken.getRefreshToken()).thenReturn("mockRefreshToken");
 
-        JwtToken resultToken = tokenService.social_AlreadyExistMember(member);
+        JwtToken resultToken = tokenService.createTokenForLoginMember(member);
 
         assertNotNull(resultToken);
         assertEquals("mockAccessToken", resultToken.getAccessToken());


### PR DESCRIPTION
#87 
- 이미 가입된 회원 검증 방식을 email이 아닌 socialId를 통해 검증하도록 수정
- TokenService의 로그인 사용자 토큰 발급 메소드 명 수정