### PR TITLE
애플 로그인 2차 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,10 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
-    implementation 'com.nimbusds:nimbus-jose-jwt:3.10'
+    implementation 'com.nimbusds:nimbus-jose-jwt:9.40'
     implementation 'com.googlecode.json-simple:json-simple:1.1.1'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
 
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
+++ b/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.dongyang.dongpo.controller.auth;
 
 import com.dongyang.dongpo.apiresponse.ApiResponse;
+import com.dongyang.dongpo.dto.auth.AppleLoginDto;
 import com.dongyang.dongpo.dto.auth.JwtToken;
 import com.dongyang.dongpo.dto.auth.JwtTokenReissueDto;
 import com.dongyang.dongpo.dto.auth.SocialTokenDto;
@@ -37,8 +38,8 @@ public class AuthController {
     }
 
     @PostMapping("/apple")
-    public ResponseEntity<ApiResponse<JwtToken>> apple(@RequestBody SocialTokenDto token) {
-        return ResponseEntity.ok(new ApiResponse<>(appleLoginService.getAppleUserInfo(token.getToken())));
+    public ResponseEntity<ApiResponse<JwtToken>> apple(@RequestBody AppleLoginDto appleLoginDto) {
+        return ResponseEntity.ok(new ApiResponse<>(appleLoginService.getAppleUserInfo(appleLoginDto)));
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/com/dongyang/dongpo/domain/auth/AppleRefreshToken.java
+++ b/src/main/java/com/dongyang/dongpo/domain/auth/AppleRefreshToken.java
@@ -1,0 +1,36 @@
+package com.dongyang.dongpo.domain.auth;
+
+import com.dongyang.dongpo.domain.member.Member;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AppleRefreshToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private String refreshToken;
+
+    @Builder.Default
+    private LocalDateTime updateDate = LocalDateTime.now();
+
+    public void updateRefreshToken(String newRefreshToken) {
+        System.out.println("AppleRefreshToken.updateRefreshToken <<");
+        this.refreshToken = newRefreshToken;
+        this.updateDate = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/dongyang/dongpo/domain/auth/AppleRefreshToken.java
+++ b/src/main/java/com/dongyang/dongpo/domain/auth/AppleRefreshToken.java
@@ -29,7 +29,6 @@ public class AppleRefreshToken {
     private LocalDateTime updateDate = LocalDateTime.now();
 
     public void updateRefreshToken(String newRefreshToken) {
-        System.out.println("AppleRefreshToken.updateRefreshToken <<");
         this.refreshToken = newRefreshToken;
         this.updateDate = LocalDateTime.now();
     }

--- a/src/main/java/com/dongyang/dongpo/dto/auth/AppleLoginDto.java
+++ b/src/main/java/com/dongyang/dongpo/dto/auth/AppleLoginDto.java
@@ -6,7 +6,6 @@ import lombok.Data;
 @Builder
 @Data
 public class AppleLoginDto {
-    private String id;
-    private String token;
-    private String email;
+    private String identityToken;
+    private String authorizationCode;
 }

--- a/src/main/java/com/dongyang/dongpo/dto/auth/AppleRefreshTokenDto.java
+++ b/src/main/java/com/dongyang/dongpo/dto/auth/AppleRefreshTokenDto.java
@@ -1,0 +1,15 @@
+package com.dongyang.dongpo.dto.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AppleRefreshTokenDto {
+    private String access_token;
+    private String expires_in;
+    private String id_token;
+    private String refresh_token;
+    private String token_type;
+    private String error;
+}

--- a/src/main/java/com/dongyang/dongpo/repository/auth/AppleRefreshTokenRepository.java
+++ b/src/main/java/com/dongyang/dongpo/repository/auth/AppleRefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package com.dongyang.dongpo.repository.auth;
+
+import com.dongyang.dongpo.domain.auth.AppleRefreshToken;
+import com.dongyang.dongpo.domain.member.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshToken, Long> {
+    Optional<AppleRefreshToken> findByMember(Member member);
+
+    void deleteByMember(Member member);
+}

--- a/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
+++ b/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
@@ -1,51 +1,57 @@
 package com.dongyang.dongpo.service.auth;
 
+import com.dongyang.dongpo.domain.auth.AppleRefreshToken;
 import com.dongyang.dongpo.domain.member.Member;
+import com.dongyang.dongpo.dto.auth.AppleLoginDto;
+import com.dongyang.dongpo.dto.auth.AppleRefreshTokenDto;
 import com.dongyang.dongpo.dto.auth.JwtToken;
 import com.dongyang.dongpo.dto.auth.UserInfo;
 import com.dongyang.dongpo.exception.CustomException;
 import com.dongyang.dongpo.exception.ErrorCode;
+import com.dongyang.dongpo.repository.auth.AppleRefreshTokenRepository;
 import com.dongyang.dongpo.service.member.MemberService;
+import com.dongyang.dongpo.util.auth.AppleKeyGenerator;
+import com.dongyang.dongpo.util.auth.ApplePublicKeyGenerator;
 import com.dongyang.dongpo.util.auth.ApplePublicKeyResponse;
 import com.dongyang.dongpo.util.auth.AppleTokenParser;
 import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 import java.security.PublicKey;
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AppleLoginService {
 
     private final AppleTokenParser appleTokenParser;
+    private final AppleKeyGenerator appleKeyGenerator;
     private final ApplePublicKeyGenerator applePublicKeyGenerator;
+    private final AppleRefreshTokenRepository appleRefreshTokenRepository;
     private final MemberService memberService;
-
-    @Value("${apple.team.id}")
-    private String appleTeamId;
-
-    @Value("${apple.login.key}")
-    private String appleLoginKey;
 
     @Value("${apple.client.id}")
     private String appleClientId;
 
-    @Value("${apple.redirect.uri}")
-    private String appleRedirectUri;
-
-    @Value("${apple.key.path}")
-    private String appleKeyPath;
-
     private final static String appleAuthUrl = "https://appleid.apple.com";
 
-    public JwtToken getAppleUserInfo(String identityToken) {
+    @Transactional
+    public JwtToken getAppleUserInfo(AppleLoginDto appleLoginDto) {
         // identityToken 파싱 작업 수행
-        Map<String, String> header = appleTokenParser.parseHeader(identityToken);
+        Map<String, String> header = appleTokenParser.parseHeader(appleLoginDto.getIdentityToken());
 
         // Apple 인증 서버로부터 공개 키 불러옴
         ApplePublicKeyResponse publicKeys = getApplePublicKeys();
@@ -54,9 +60,11 @@ public class AppleLoginService {
         PublicKey publicKey = applePublicKeyGenerator.generate(header, publicKeys);
 
         // identityToken 검증 작업 수행 및 클레임 추출
-        Claims claims = validateIdentityToken(identityToken, publicKey);
+        Claims claims = validateIdentityToken(appleLoginDto.getIdentityToken(), publicKey);
 
-        return memberService.socialSave(UserInfo.builder()
+        String appleRefreshToken = getAppleRefreshToken(appleLoginDto.getAuthorizationCode());
+
+        JwtToken jwtToken = memberService.socialSave(UserInfo.builder()
                 .id(claims.get("sub", String.class))
                 .email(claims.get("email", String.class))
                 .name("TEMP_NAME") // 임시
@@ -65,6 +73,12 @@ public class AppleLoginService {
                 .gender(Member.Gender.GEN_MALE) // 임시
                 .provider(Member.SocialType.APPLE)
                 .build());
+
+        Member claimingMember = memberService.findByEmail(claims.get("email", String.class));
+
+        saveOrUpdateRefreshToken(claimingMember, appleRefreshToken);
+
+        return jwtToken;
     }
 
     private Claims validateIdentityToken(String identityToken, PublicKey publicKey) {
@@ -96,5 +110,55 @@ public class AppleLoginService {
                 .retrieve()
                 .bodyToMono(ApplePublicKeyResponse.class)
                 .block();
+    }
+
+    // Apple 인증 서버에 RefreshToken 요청
+    private String getAppleRefreshToken(String authorizationCode) {
+        MultiValueMap<String, String> body = getCreateTokenBody(authorizationCode);
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(appleAuthUrl)
+                .build();
+
+        try {
+            AppleRefreshTokenDto appleTokenResponse = webClient.post()
+                    .uri("/auth/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData(body))
+                    .retrieve()
+                    .bodyToMono(AppleRefreshTokenDto.class)
+                    .block();
+
+            return Objects.requireNonNull(appleTokenResponse).getRefresh_token();
+        } catch (WebClientResponseException e) {
+            throw new CustomException(ErrorCode.SOCIAL_TOKEN_NOT_VALID);
+
+        }
+    }
+
+    private MultiValueMap<String, String> getCreateTokenBody(String authorizationCode) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("code", authorizationCode);
+        body.add("client_id", appleClientId);
+        body.add("client_secret", appleKeyGenerator.generateClientSecret());
+        body.add("grant_type", "authorization_code");
+        return body;
+    }
+
+    @Transactional
+    public void saveOrUpdateRefreshToken(Member member, String newRefreshToken) {
+        AppleRefreshToken existingToken = appleRefreshTokenRepository.findByMember(member).orElse(null);
+
+        // 이미 해당 사용자에 대한 RefreshToken이 존재하는 경우 업데이트
+        if (existingToken != null) {
+            System.out.println("AppleRefreshToken.updateRefreshToken <<");
+            existingToken.updateRefreshToken(newRefreshToken);
+        } else { // 혹은 새로운 RefreshToken 저장
+            AppleRefreshToken newToken = AppleRefreshToken.builder()
+                    .member(member)
+                    .refreshToken(newRefreshToken)
+                    .build();
+            appleRefreshTokenRepository.save(newToken);
+        }
     }
 }

--- a/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
+++ b/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
@@ -151,7 +151,6 @@ public class AppleLoginService {
 
         // 이미 해당 사용자에 대한 RefreshToken이 존재하는 경우 업데이트
         if (existingToken != null) {
-            System.out.println("AppleRefreshToken.updateRefreshToken <<");
             existingToken.updateRefreshToken(newRefreshToken);
         } else { // 혹은 새로운 RefreshToken 저장
             AppleRefreshToken newToken = AppleRefreshToken.builder()

--- a/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
+++ b/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
@@ -76,6 +76,10 @@ public class MemberService {
         return memberRepository.findById(id).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
+    public Member findByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+    }
+
     public MyPageDto getMemberInfoIndex(Member member) {
         List<MemberTitle> memberTitles = memberTitleRepository.findByMember(member);
         Long storeRegisterCount = storeService.getMyRegisteredStoreCount(member);

--- a/src/main/java/com/dongyang/dongpo/util/auth/AppleKeyGenerator.java
+++ b/src/main/java/com/dongyang/dongpo/util/auth/AppleKeyGenerator.java
@@ -1,0 +1,69 @@
+package com.dongyang.dongpo.util.auth;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.security.PrivateKey;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class AppleKeyGenerator {
+
+    @Value("${apple.team.id}")
+    private String appleTeamId; // iss
+
+    @Value("${apple.login.key}")
+    private String appleLoginKey; // kid
+
+    @Value("${apple.client.id}")
+    private String appleClientId; // sub
+
+    @Value("${apple.key.content}")
+    private String appleKeyContent; // private key
+
+    private final static String appleAuthUrl = "https://appleid.apple.com"; // aud
+
+    // client_secret 생성
+    public String generateClientSecret() {
+        Date expirationDate = Date.from(LocalDateTime.now().plusDays(30).atZone(ZoneId.systemDefault()).toInstant());
+
+        return Jwts.builder()
+                .setHeaderParam("kid", appleLoginKey)
+                .setHeaderParam("alg", "ES256")
+                .setIssuer(appleTeamId)
+                .setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(expirationDate)
+                .setAudience(appleAuthUrl)
+                .setSubject(appleClientId)
+                .signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+                .compact();
+    }
+
+    // key.p8 파일을 읽어와 PrivateKey 객체로 변환
+    private PrivateKey getPrivateKey() {
+        try {
+            Reader pemReader = new StringReader(appleKeyContent.replace("\\n", "\n"));
+            PEMParser pemParser = new PEMParser(pemReader);
+            JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+            PrivateKeyInfo object = (PrivateKeyInfo)pemParser.readObject();
+            return converter.getPrivateKey(object);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read key: " + appleKeyContent, e);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load private key", e);
+        }
+    }
+
+}

--- a/src/main/java/com/dongyang/dongpo/util/auth/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/dongyang/dongpo/util/auth/ApplePublicKeyGenerator.java
@@ -1,9 +1,8 @@
-package com.dongyang.dongpo.service.auth;
+package com.dongyang.dongpo.util.auth;
 
 import com.dongyang.dongpo.dto.auth.ApplePublicKeyDto;
 import com.dongyang.dongpo.exception.CustomException;
 import com.dongyang.dongpo.exception.ErrorCode;
-import com.dongyang.dongpo.util.auth.ApplePublicKeyResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 


### PR DESCRIPTION
#30 
- RefreshToken 발급 위해 로그인 시 authorization_code 까지 수집하는 것으로 수정
- RefreshToken 관리용 엔티티 추가
- 사용자 회원 가입, 로그인 시 발급되는 RefreshToken 저장