### PR TITLE
애플 로그인 3차 구현

### DIFF
--- a/.github/workflows/cicd_workflow.yml
+++ b/.github/workflows/cicd_workflow.yml
@@ -17,10 +17,6 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
 
-      - name: Set up Apple Key File
-        run: |
-          mkdir src/main/resources/key
-          echo "${{ secrets.APPLE_KEY }}" > src/main/resources/key/key.p8
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
+++ b/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
@@ -1,6 +1,7 @@
 package com.dongyang.dongpo.controller.auth;
 
 import com.dongyang.dongpo.apiresponse.ApiResponse;
+import com.dongyang.dongpo.domain.member.Member;
 import com.dongyang.dongpo.dto.auth.AppleLoginDto;
 import com.dongyang.dongpo.dto.auth.JwtToken;
 import com.dongyang.dongpo.dto.auth.JwtTokenReissueDto;
@@ -11,6 +12,7 @@ import com.dongyang.dongpo.service.token.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -40,6 +42,12 @@ public class AuthController {
     @PostMapping("/apple")
     public ResponseEntity<ApiResponse<JwtToken>> apple(@RequestBody AppleLoginDto appleLoginDto) {
         return ResponseEntity.ok(new ApiResponse<>(appleLoginService.getAppleUserInfo(appleLoginDto)));
+    }
+
+    @PostMapping("/apple/leave")
+    public ResponseEntity<ApiResponse<String>> appleLeaveTest(@AuthenticationPrincipal Member member) {
+        appleLoginService.revokeToken(member);
+        return ResponseEntity.ok(new ApiResponse<>("Leave success."));
     }
 
     @PostMapping("/reissue")

--- a/src/main/java/com/dongyang/dongpo/domain/member/Member.java
+++ b/src/main/java/com/dongyang/dongpo/domain/member/Member.java
@@ -80,6 +80,11 @@ public class Member implements UserDetails {
         this.mainTitle = newMainTitle;
     }
 
+    public void setMemberStatusLeave() {
+        this.status = Status.LEAVE;
+        this.leaveDate = LocalDateTime.now();
+    }
+
     public static Member toEntity(UserInfo userInfo){
         return Member.builder()
                 .email(userInfo.getEmail())

--- a/src/main/java/com/dongyang/dongpo/exception/ErrorCode.java
+++ b/src/main/java/com/dongyang/dongpo/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
 	REPORT_REASON_TEXT_REQUIRED(400, "기타 사유는 사유를 작성해야 합니다."),
 
     UNAUTHORIZED(403, "권한이 없습니다."),
+    MEMBER_ALREADY_LEFT(403, "탈퇴한 회원입니다."),
     ;
 
     private final int code;

--- a/src/main/java/com/dongyang/dongpo/repository/member/MemberRepository.java
+++ b/src/main/java/com/dongyang/dongpo/repository/member/MemberRepository.java
@@ -9,6 +9,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
+    Optional<Member> findBySocialId(String socialId);
+
     Boolean existsBySocialId(String socialId);
 
     Boolean existsByEmail(String email);

--- a/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
+++ b/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
@@ -160,4 +160,46 @@ public class AppleLoginService {
             appleRefreshTokenRepository.save(newToken);
         }
     }
+
+    // 애플 로그인 사용자 탈퇴 메소드
+    @Transactional
+    public void revokeToken(Member member) {
+        AppleRefreshToken refresh = appleRefreshTokenRepository.findByMember(member)
+                .orElseThrow(() -> new CustomException(ErrorCode.MALFORMED_TOKEN));
+
+        MultiValueMap<String, String> revokeTokenBody = getRevokeTokenBody(refresh.getRefreshToken());
+
+        WebClient webClient = WebClient.builder()
+                .baseUrl(appleAuthUrl)
+                .build();
+
+        // RefreshToken revoke 요청
+        webClient.post()
+                .uri("/auth/revoke")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(BodyInserters.fromFormData(revokeTokenBody))
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block();
+
+        // DB 속 해당 사용자의 RefreshToken 삭제
+        appleRefreshTokenRepository.deleteByMember(member);
+
+        // 사용자 상태를 탈퇴로 변경
+        memberService.findByEmail(member.getEmail()).setMemberStatusLeave();
+
+//        // 사용자 상태를 탈퇴로 변경
+//        member.setMemberStatusLeave();
+
+        log.info("Member {} Account has been successfully revoked.", member.getEmail());
+    }
+
+    public MultiValueMap<String, String> getRevokeTokenBody(String refreshToken) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("client_id", appleClientId);
+        body.add("client_secret", appleKeyGenerator.generateClientSecret());
+        body.add("token", refreshToken);
+        body.add("token_type_hint", "refresh_token");
+        return body;
+    }
 }

--- a/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
+++ b/src/main/java/com/dongyang/dongpo/service/auth/AppleLoginService.java
@@ -188,9 +188,6 @@ public class AppleLoginService {
         // 사용자 상태를 탈퇴로 변경
         memberService.findByEmail(member.getEmail()).setMemberStatusLeave();
 
-//        // 사용자 상태를 탈퇴로 변경
-//        member.setMemberStatusLeave();
-
         log.info("Member {} Account has been successfully revoked.", member.getEmail());
     }
 


### PR DESCRIPTION
#30 
탈퇴 처리 구현
- 로그인 시 사용자 상태 검증 로직 추가 (Status LEAVE일 경우 로그인 불가 처리)
- Apple key는 환경 변수를 통해 불러오도록 수정