### PR TITLE
애플 로그인 4차 구현

### DIFF
--- a/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
+++ b/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
@@ -2,15 +2,14 @@ package com.dongyang.dongpo.controller.auth;
 
 import com.dongyang.dongpo.apiresponse.ApiResponse;
 import com.dongyang.dongpo.domain.member.Member;
-import com.dongyang.dongpo.dto.auth.AppleLoginDto;
-import com.dongyang.dongpo.dto.auth.JwtToken;
-import com.dongyang.dongpo.dto.auth.JwtTokenReissueDto;
-import com.dongyang.dongpo.dto.auth.SocialTokenDto;
+import com.dongyang.dongpo.dto.auth.*;
+import com.dongyang.dongpo.exception.ErrorCode;
 import com.dongyang.dongpo.service.auth.AppleLoginService;
 import com.dongyang.dongpo.service.auth.SocialService;
 import com.dongyang.dongpo.service.token.TokenService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -40,8 +39,17 @@ public class AuthController {
     }
 
     @PostMapping("/apple")
-    public ResponseEntity<ApiResponse<JwtToken>> apple(@RequestBody AppleLoginDto appleLoginDto) {
-        return ResponseEntity.ok(new ApiResponse<>(appleLoginService.getAppleUserInfo(appleLoginDto)));
+    public ResponseEntity<ApiResponse<?>> apple(@RequestBody AppleLoginDto appleLoginDto) {
+        AppleLoginResponse response = appleLoginService.getAppleUserInfo(appleLoginDto);
+
+        return response.getJwtToken() == null
+                ? ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse<>(response.getClaims(), ErrorCode.ADDITIONAL_INFO_REQUIRED_FOR_SIGNUP.toString()))
+                : ResponseEntity.ok(new ApiResponse<>(response.getJwtToken()));
+    }
+
+    @PostMapping("/apple/continue")
+    public ResponseEntity<ApiResponse<JwtToken>> appleSignupContinue(@RequestBody AppleSignupContinueDto appleSignupContinueDto) {
+        return ResponseEntity.ok(new ApiResponse<>(appleLoginService.continueSignup(appleSignupContinueDto)));
     }
 
     @PostMapping("/apple/leave")

--- a/src/main/java/com/dongyang/dongpo/domain/auth/AppleRefreshToken.java
+++ b/src/main/java/com/dongyang/dongpo/domain/auth/AppleRefreshToken.java
@@ -19,9 +19,8 @@ public class AppleRefreshToken {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
-    private Member member;
+    @Column(unique = true)
+    private String socialId; // 애플 유저 식별자
 
     private String refreshToken;
 

--- a/src/main/java/com/dongyang/dongpo/dto/auth/AppleLoginResponse.java
+++ b/src/main/java/com/dongyang/dongpo/dto/auth/AppleLoginResponse.java
@@ -1,0 +1,39 @@
+package com.dongyang.dongpo.dto.auth;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.jsonwebtoken.Claims;
+import lombok.*;
+
+@Getter
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AppleLoginResponse {
+    private ClaimsResponse claims;
+    private JwtToken jwtToken;
+
+    @Getter
+    @Builder
+    @JsonSerialize
+    @JsonDeserialize
+    private static class ClaimsResponse {
+        private String socialId;
+        private String email;
+    }
+
+    public static AppleLoginResponse responseClaims(Claims claims) {
+        return AppleLoginResponse.builder()
+                .claims(ClaimsResponse.builder()
+                        .socialId(claims.get("sub", String.class))
+                        .email(claims.get("email", String.class))
+                        .build())
+                .build();
+    }
+
+    public static AppleLoginResponse responseJwtToken(JwtToken jwtToken) {
+        return AppleLoginResponse.builder()
+                .jwtToken(jwtToken)
+                .build();
+    }
+}

--- a/src/main/java/com/dongyang/dongpo/dto/auth/AppleSignupContinueDto.java
+++ b/src/main/java/com/dongyang/dongpo/dto/auth/AppleSignupContinueDto.java
@@ -1,0 +1,15 @@
+package com.dongyang.dongpo.dto.auth;
+
+import com.dongyang.dongpo.domain.member.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class AppleSignupContinueDto {
+    private String nickname;
+    private String birthday;
+    private Member.Gender gender;
+    private String socialId;
+    private String email;
+}

--- a/src/main/java/com/dongyang/dongpo/dto/auth/AppleTokenResponseDto.java
+++ b/src/main/java/com/dongyang/dongpo/dto/auth/AppleTokenResponseDto.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class AppleRefreshTokenDto {
+public class AppleTokenResponseDto {
     private String access_token;
     private String expires_in;
     private String id_token;

--- a/src/main/java/com/dongyang/dongpo/exception/ErrorCode.java
+++ b/src/main/java/com/dongyang/dongpo/exception/ErrorCode.java
@@ -16,16 +16,24 @@ public enum ErrorCode {
     EXPIRED_TOKEN(401, "토큰이 만료되었습니다."),
     UNSUPPORTED_TOKEN(401, "지원하지 않는 토큰입니다."),
     MALFORMED_TOKEN(401, "토큰이 잘못되었습니다."),
+    TOKEN_ISSUER_MISMATCH(401, "토큰 발급자가 일치하지 않습니다."),
+    TOKEN_AUDIENCE_MISMATCH(401, "토큰 수신 대상자가 일치하지 않습니다."),
 
     STORE_REGISTRATION_NOT_VALID(400, "위치 정보가 오차를 벗어났습니다."),
     ARGUMENT_NOT_SATISFIED(400, "요청이 잘못되었습니다."),
     BOOKMARK_ALREADY_EXISTS(400, "해당 점포의 북마크가 이미 존재합니다."),
 	REPORT_REASON_TEXT_REQUIRED(400, "기타 사유는 사유를 작성해야 합니다."),
+    ADDITIONAL_INFO_REQUIRED_FOR_SIGNUP(400, "회원 가입에 필요한 추가 정보 요청."),
+    APPLE_AUTHORIZATION_CODE_EXPIRED(400, "Apple 인증 코드가 만료되었습니다."),
+    APPLE_PUBLIC_KEY_GENERATION_FAILED(400, "Apple 공개키 생성에 실패하였습니다."),
+    HEADER_PARSING_FAILED(400, "헤더 파싱에 실패하였습니다."),
+    CLAIMS_EXTRACTION_FAILED(400, "토큰 정보 추출에 실패하였습니다."),
 
     UNAUTHORIZED(403, "권한이 없습니다."),
     MEMBER_ALREADY_LEFT(403, "탈퇴한 회원입니다."),
 
     MEMBER_EMAIL_DUPLICATED(409, "이미 사용중인 이메일입니다."),
+    MEMBER_ALREADY_EXISTS(409, "이미 가입된 회원입니다."),
     ;
 
     private final int code;

--- a/src/main/java/com/dongyang/dongpo/repository/auth/AppleRefreshTokenRepository.java
+++ b/src/main/java/com/dongyang/dongpo/repository/auth/AppleRefreshTokenRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface AppleRefreshTokenRepository extends JpaRepository<AppleRefreshToken, Long> {
-    Optional<AppleRefreshToken> findByMember(Member member);
+    Optional<AppleRefreshToken> findBySocialId(String socialId);
 
-    void deleteByMember(Member member);
+    void deleteBySocialId(String socialId);
 }

--- a/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
+++ b/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
@@ -3,6 +3,8 @@ package com.dongyang.dongpo.service.member;
 import com.dongyang.dongpo.domain.RefreshToken;
 import com.dongyang.dongpo.domain.member.Member;
 import com.dongyang.dongpo.domain.member.MemberTitle;
+import com.dongyang.dongpo.dto.auth.AppleLoginResponse;
+import com.dongyang.dongpo.dto.auth.AppleSignupContinueDto;
 import com.dongyang.dongpo.dto.auth.JwtToken;
 import com.dongyang.dongpo.dto.auth.UserInfo;
 import com.dongyang.dongpo.dto.mypage.MyPageDto;
@@ -16,6 +18,7 @@ import com.dongyang.dongpo.repository.member.MemberTitleRepository;
 import com.dongyang.dongpo.s3.S3Service;
 import com.dongyang.dongpo.service.store.StoreService;
 import com.dongyang.dongpo.service.token.TokenService;
+import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -44,24 +47,75 @@ public class MemberService {
     @Transactional
     public JwtToken socialSave(UserInfo userInfo){
         Member member = Member.toEntity(userInfo);
+        if (validateMemberExistence(member.getEmail(), member.getSocialId()))
+            return tokenService.createTokenForLoginMember(member);
 
+        return registerMemberAndCreateToken(member);
+    }
+
+    // 애플 로그인 수행 메소드
+    public AppleLoginResponse handleAppleLogin(Claims claims) {
+        final String socialId = claims.get("sub", String.class);
+        final String email = claims.get("email", String.class);
+
+        // 이미 존재하는 회원인지 검증
+        if (validateMemberExistence(email, socialId)) {
+            Member existingMember = memberRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+            return AppleLoginResponse.responseJwtToken(tokenService.createTokenForLoginMember(existingMember));
+        }
+
+        // 존재하지 않는 회원인 경우 필수 클레임 정보 반환
+        return AppleLoginResponse.responseClaims(claims);
+    }
+
+    // 애플 회원 가입 수행 메소드(추가 정보 기입)
+    @Transactional
+    public JwtToken continueAppleSignup(AppleSignupContinueDto appleSignupContinueDto) {
+
+        // 이미 가입된 회원인지, 가입 가능한 회원인지 검증
+        if (validateMemberExistence(appleSignupContinueDto.getEmail(), appleSignupContinueDto.getSocialId()))
+            throw new CustomException(ErrorCode.MEMBER_ALREADY_EXISTS);
+
+        Member member = Member.toEntity(UserInfo.builder()
+                .email(appleSignupContinueDto.getEmail())
+                .nickname(appleSignupContinueDto.getNickname())
+                .birthyear(appleSignupContinueDto.getBirthday().substring(0, 4))
+                .birthday(appleSignupContinueDto.getBirthday().substring(5))
+                .gender(appleSignupContinueDto.getGender())
+                .provider(Member.SocialType.APPLE)
+                .id(appleSignupContinueDto.getSocialId())
+                .build()
+        );
+
+        // 가입 처리 및 토큰 발급
+        return registerMemberAndCreateToken(member);
+    }
+
+    // 이미 가입 된 회원인지, 가입 가능한 회원인지 검증
+    public boolean validateMemberExistence(String email, String socialId) {
         // 이미 가입된 회원인 경우
-        if (memberRepository.existsBySocialId(member.getSocialId())) {
-            Member existingMember = memberRepository.findBySocialId(member.getSocialId())
+        if (memberRepository.existsBySocialId(socialId)) {
+            Member existingMember = memberRepository.findBySocialId(socialId)
                     .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
             // 탈퇴한 회원인 경우
             if (existingMember.getStatus() == Member.Status.LEAVE)
                 throw new CustomException(ErrorCode.MEMBER_ALREADY_LEFT);
 
-            // 로그인 처리
-            return tokenService.createTokenForLoginMember(existingMember);
+            // 모든 조건 통과 시 로그인 처리
+            return true;
         }
 
-        // 신규 가입 회원의 이메일이 중복될 경우 예외 발생
-        if (memberRepository.existsByEmail(member.getEmail()))
+        // 가입 되지 않은 회원일 경우, 이메일 중복 검사
+        if (memberRepository.existsByEmail(email))
             throw new CustomException(ErrorCode.MEMBER_EMAIL_DUPLICATED);
 
+        return false;
+    }
+
+    // 회원 가입 처리 및 토큰 발급
+    private JwtToken registerMemberAndCreateToken(Member member) {
         memberRepository.save(member);
         memberTitleRepository.save(MemberTitle.builder()
                 .member(member)

--- a/src/main/java/com/dongyang/dongpo/util/auth/ApplePublicKeyGenerator.java
+++ b/src/main/java/com/dongyang/dongpo/util/auth/ApplePublicKeyGenerator.java
@@ -39,7 +39,7 @@ public class ApplePublicKeyGenerator {
             KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.getKty());
             return keyFactory.generatePublic(rsaPublicKeySpec);
         } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
-            throw new CustomException(ErrorCode.SOCIAL_TOKEN_NOT_VALID);
+            throw new CustomException(ErrorCode.APPLE_PUBLIC_KEY_GENERATION_FAILED);
         }
     }
 

--- a/src/main/java/com/dongyang/dongpo/util/auth/AppleTokenParser.java
+++ b/src/main/java/com/dongyang/dongpo/util/auth/AppleTokenParser.java
@@ -30,9 +30,9 @@ public class AppleTokenParser {
             final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader), StandardCharsets.UTF_8);
             return objectMapper.readValue(decodedHeader, Map.class);
         } catch (JsonMappingException e) {
-            throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN);
+            throw new CustomException(ErrorCode.HEADER_PARSING_FAILED);
         } catch (JsonProcessingException e) {
-            throw new CustomException(ErrorCode.MALFORMED_TOKEN);
+            throw new CustomException(ErrorCode.HEADER_PARSING_FAILED);
         }
     }
 
@@ -44,9 +44,9 @@ public class AppleTokenParser {
                     .parseClaimsJws(identityToken)
                     .getBody();
         } catch (IllegalArgumentException e) {
-            throw new CustomException(ErrorCode.MALFORMED_TOKEN);
+            throw new CustomException(ErrorCode.CLAIMS_EXTRACTION_FAILED);
         } catch (JwtException e) {
-            throw new CustomException(ErrorCode.CLAIMS_NOT_FOUND);
+            throw new CustomException(ErrorCode.MALFORMED_TOKEN);
         }
     }
 }


### PR DESCRIPTION
#30 
- 로그인 프로세스 세분화 (추가 정보 입력 및 회원 가입 프로세스 분리)
- Apple RefreshToken 관리 방식 수정
- 예외 처리 세분화