### PR TITLE
feat: 로그아웃 구현

### DIFF
--- a/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
+++ b/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
@@ -37,6 +37,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/admin/**").denyAll()
                         .requestMatchers("/api/**").authenticated()
+                        .requestMatchers("/auth/logout").authenticated()
                         .requestMatchers("/auth/**").permitAll()
                         .anyRequest().permitAll()
                 )

--- a/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
+++ b/src/main/java/com/dongyang/dongpo/controller/auth/AuthController.java
@@ -63,4 +63,12 @@ public class AuthController {
     public ResponseEntity<ApiResponse<JwtToken>> reissue(@RequestBody JwtTokenReissueDto jwtTokenReissueDto) {
         return ResponseEntity.ok(new ApiResponse<>(tokenService.reissueAccessToken(jwtTokenReissueDto)));
     }
+
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃")
+    public ResponseEntity<ApiResponse<String>> logout(@AuthenticationPrincipal Member member,
+                                                      @RequestHeader("Authorization") String authorization) {
+        socialService.doLogout(member, authorization);
+        return ResponseEntity.ok(new ApiResponse<>("Logout success."));
+    }
 }

--- a/src/main/java/com/dongyang/dongpo/domain/auth/RefreshToken.java
+++ b/src/main/java/com/dongyang/dongpo/domain/auth/RefreshToken.java
@@ -1,4 +1,4 @@
-package com.dongyang.dongpo.domain;
+package com.dongyang.dongpo.domain.auth;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dongyang/dongpo/domain/auth/TokenBlacklist.java
+++ b/src/main/java/com/dongyang/dongpo/domain/auth/TokenBlacklist.java
@@ -1,0 +1,16 @@
+package com.dongyang.dongpo.domain.auth;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.index.Indexed;
+
+@Getter
+@Builder
+@RedisHash(value = "blacklist", timeToLive = 1800) // 30분
+public class TokenBlacklist {
+    @Id
+    @Indexed
+    private String accessToken;
+}

--- a/src/main/java/com/dongyang/dongpo/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dongyang/dongpo/jwt/JwtAuthenticationFilter.java
@@ -25,6 +25,8 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         try {
             String token = resolveToken((HttpServletRequest) servletRequest);
 
+            jwtTokenProvider.isBlacklisted(token);
+
             if (jwtTokenProvider.validateToken(token)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/com/dongyang/dongpo/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/com/dongyang/dongpo/repository/auth/RefreshTokenRepository.java
@@ -1,6 +1,6 @@
-package com.dongyang.dongpo.repository;
+package com.dongyang.dongpo.repository.auth;
 
-import com.dongyang.dongpo.domain.RefreshToken;
+import com.dongyang.dongpo.domain.auth.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
@@ -9,4 +9,6 @@ public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Str
 
     Optional<RefreshToken> findByEmail(String email);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
+
+    void deleteById(String email);
 }

--- a/src/main/java/com/dongyang/dongpo/repository/auth/TokenBlacklistRepository.java
+++ b/src/main/java/com/dongyang/dongpo/repository/auth/TokenBlacklistRepository.java
@@ -1,0 +1,8 @@
+package com.dongyang.dongpo.repository.auth;
+
+import com.dongyang.dongpo.domain.auth.TokenBlacklist;
+import org.springframework.data.repository.CrudRepository;
+
+public interface TokenBlacklistRepository extends CrudRepository<TokenBlacklist, String> {
+    boolean existsByAccessToken(String accessToken);
+}

--- a/src/main/java/com/dongyang/dongpo/service/auth/SocialService.java
+++ b/src/main/java/com/dongyang/dongpo/service/auth/SocialService.java
@@ -152,4 +152,9 @@ public class SocialService {
                 throw e;
         }
     }
+
+    public void doLogout(Member member, String authorization) {
+        memberService.handleLogout(member, authorization);
+
+    }
 }

--- a/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
+++ b/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
@@ -1,6 +1,6 @@
 package com.dongyang.dongpo.service.member;
 
-import com.dongyang.dongpo.domain.RefreshToken;
+import com.dongyang.dongpo.domain.auth.RefreshToken;
 import com.dongyang.dongpo.domain.member.Member;
 import com.dongyang.dongpo.domain.member.MemberTitle;
 import com.dongyang.dongpo.dto.auth.AppleLoginResponse;
@@ -13,7 +13,7 @@ import com.dongyang.dongpo.exception.CustomException;
 import com.dongyang.dongpo.exception.ErrorCode;
 import com.dongyang.dongpo.jwt.JwtTokenProvider;
 import com.dongyang.dongpo.repository.member.MemberRepository;
-import com.dongyang.dongpo.repository.RefreshTokenRepository;
+import com.dongyang.dongpo.repository.auth.RefreshTokenRepository;
 import com.dongyang.dongpo.repository.member.MemberTitleRepository;
 import com.dongyang.dongpo.s3.S3Service;
 import com.dongyang.dongpo.service.store.StoreService;
@@ -175,5 +175,10 @@ public class MemberService {
             member.updateMemberMainTitle(memberTitle.getTitle());
             log.info("Member {} - updated mainTitle", member.getEmail());
         }
+    }
+
+    @Transactional
+    public void handleLogout(Member member, String authorization) {
+        tokenService.expireTokens(member.getEmail(), authorization);
     }
 }

--- a/src/main/java/com/dongyang/dongpo/service/token/TokenService.java
+++ b/src/main/java/com/dongyang/dongpo/service/token/TokenService.java
@@ -1,13 +1,13 @@
 package com.dongyang.dongpo.service.token;
 
-import com.dongyang.dongpo.domain.RefreshToken;
+import com.dongyang.dongpo.domain.auth.RefreshToken;
 import com.dongyang.dongpo.domain.member.Member;
 import com.dongyang.dongpo.dto.auth.JwtToken;
 import com.dongyang.dongpo.dto.auth.JwtTokenReissueDto;
 import com.dongyang.dongpo.exception.CustomException;
 import com.dongyang.dongpo.exception.ErrorCode;
 import com.dongyang.dongpo.jwt.JwtTokenProvider;
-import com.dongyang.dongpo.repository.RefreshTokenRepository;
+import com.dongyang.dongpo.repository.auth.RefreshTokenRepository;
 import com.dongyang.dongpo.repository.member.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,5 +57,12 @@ public class TokenService {
         refreshTokenRepository.save(refreshToken);
         log.info("Member Login : {}", member.getEmail());
         return jwtToken;
+    }
+
+    @Transactional
+    public void expireTokens(String email, String authorization) {
+        refreshTokenRepository.deleteById(email);
+
+        jwtTokenProvider.blacklistToken(authorization);
     }
 }

--- a/src/test/java/com/dongyang/dongpo/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dongyang/dongpo/service/member/MemberServiceTest.java
@@ -5,7 +5,7 @@ import com.dongyang.dongpo.domain.member.MemberTitle;
 import com.dongyang.dongpo.domain.member.Title;
 import com.dongyang.dongpo.dto.mypage.MyPageUpdateDto;
 import com.dongyang.dongpo.jwt.JwtTokenProvider;
-import com.dongyang.dongpo.repository.RefreshTokenRepository;
+import com.dongyang.dongpo.repository.auth.RefreshTokenRepository;
 import com.dongyang.dongpo.repository.member.MemberRepository;
 import com.dongyang.dongpo.repository.member.MemberTitleRepository;
 import com.dongyang.dongpo.s3.S3Service;

--- a/src/test/java/com/dongyang/dongpo/service/token/TokenServiceTest.java
+++ b/src/test/java/com/dongyang/dongpo/service/token/TokenServiceTest.java
@@ -1,13 +1,13 @@
 package com.dongyang.dongpo.service.token;
 
-import com.dongyang.dongpo.domain.RefreshToken;
+import com.dongyang.dongpo.domain.auth.RefreshToken;
 import com.dongyang.dongpo.domain.member.Member;
 import com.dongyang.dongpo.dto.auth.JwtToken;
 import com.dongyang.dongpo.dto.auth.JwtTokenReissueDto;
 import com.dongyang.dongpo.exception.CustomException;
 import com.dongyang.dongpo.exception.ErrorCode;
 import com.dongyang.dongpo.jwt.JwtTokenProvider;
-import com.dongyang.dongpo.repository.RefreshTokenRepository;
+import com.dongyang.dongpo.repository.auth.RefreshTokenRepository;
 import com.dongyang.dongpo.repository.member.MemberRepository;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
#86 
- 로그아웃 시 사용자의 accessToken, refreshToken 만료 처리
- 만료 된 토큰으로는 요청 불가능하도록 함