### PR TITLE
refactor: 인증 로직 수정

### DIFF
--- a/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
+++ b/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
@@ -1,9 +1,12 @@
 package com.dongyang.dongpo.config.security;
 
 import com.dongyang.dongpo.util.jwt.JwtAuthenticationFilter;
+import com.dongyang.dongpo.util.jwt.JwtAuthenticationProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,6 +23,7 @@ public class SecurityConfig {
     private final AuthenticationEntryPoint entryPoint;
     private final CustomUserDetailsService customUserDetailsService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -39,5 +43,12 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(entryPoint))
                 .build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder auth = http.getSharedObject(AuthenticationManagerBuilder.class);
+        auth.authenticationProvider(jwtAuthenticationProvider);
+        return auth.build();
     }
 }

--- a/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
+++ b/src/main/java/com/dongyang/dongpo/config/security/SecurityConfig.java
@@ -22,7 +22,6 @@ public class SecurityConfig {
 
     private final AuthenticationEntryPoint entryPoint;
     private final CustomUserDetailsService customUserDetailsService;
-    private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
     @Bean
@@ -40,7 +39,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .userDetailsService(customUserDetailsService)
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(authenticationManager(http)), UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(entryPoint))
                 .build();
     }

--- a/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
+++ b/src/main/java/com/dongyang/dongpo/service/member/MemberService.java
@@ -16,7 +16,7 @@ import com.dongyang.dongpo.repository.member.MemberRepository;
 import com.dongyang.dongpo.repository.member.MemberTitleRepository;
 import com.dongyang.dongpo.service.store.StoreService;
 import com.dongyang.dongpo.service.token.TokenService;
-import com.dongyang.dongpo.util.jwt.JwtTokenProvider;
+import com.dongyang.dongpo.util.jwt.JwtUtil;
 import com.dongyang.dongpo.util.s3.S3Service;
 import io.jsonwebtoken.Claims;
 import io.micrometer.common.util.StringUtils;
@@ -36,7 +36,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUtil jwtUtil;
     private final TokenService tokenService;
     private final MemberTitleRepository memberTitleRepository;
     private final StoreService storeService;
@@ -130,7 +130,7 @@ public class MemberService {
                 .achieveDate(LocalDateTime.now())
                 .build());
 
-        JwtToken jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole());
+        JwtToken jwtToken = jwtUtil.createToken(member.getEmail(), member.getRole());
         RefreshToken refreshToken = RefreshToken.builder()
                 .email(member.getEmail())
                 .refreshToken(jwtToken.getRefreshToken())

--- a/src/main/java/com/dongyang/dongpo/util/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dongyang/dongpo/util/jwt/CustomAuthenticationEntryPoint.java
@@ -9,8 +9,6 @@ import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 
-import java.io.IOException;
-
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
     private final HandlerExceptionResolver resolver;
@@ -20,7 +18,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     }
 
     @Override
-    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
         resolver.resolveException(request, response, null, (Exception) request.getAttribute("exception"));
     }
 }

--- a/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationFilter.java
@@ -2,48 +2,63 @@ package com.dongyang.dongpo.util.jwt;
 
 import com.dongyang.dongpo.exception.CustomException;
 import com.dongyang.dongpo.exception.ErrorCode;
+import io.netty.util.internal.StringUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
 @Slf4j
+@Component
 @RequiredArgsConstructor
-public class JwtAuthenticationFilter extends GenericFilterBean {
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    private final JwtTokenProvider jwtTokenProvider;
+    private final String HEADER_PREFIX = "Authorization";
+    private final String TOKEN_PREFIX = "Bearer ";
+
+    private final JwtUtil jwtUtil;
 
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
-            String token = resolveToken((HttpServletRequest) servletRequest);
-
-            jwtTokenProvider.isBlacklisted(token);
-
-            if (jwtTokenProvider.validateToken(token)) {
-                Authentication authentication = jwtTokenProvider.getAuthentication(token);
-                SecurityContextHolder.getContext().setAuthentication(authentication);
-            }
-        }catch (Exception e){
-            servletRequest.setAttribute("exception", e);
-        }finally {
-            filterChain.doFilter(servletRequest, servletResponse);
+            String token = resolveToken(request.getHeader(HEADER_PREFIX));
+            validateToken(token);
+            setAuthentication(getAuthentication(token));
+        } catch (Exception e) {
+            request.setAttribute("exception", e);
+        } finally {
+            filterChain.doFilter(request, response);
         }
     }
 
-    private String resolveToken(HttpServletRequest servletRequest) throws Exception{
-        String token = servletRequest.getHeader("Authorization");
-        if (token == null || !token.startsWith("Bearer "))
+    // 토큰 유효성 검증 및 파싱
+    private String resolveToken(String authorizationHeader) {
+        if (StringUtil.isNullOrEmpty(authorizationHeader) || !authorizationHeader.startsWith(TOKEN_PREFIX))
             throw new CustomException(ErrorCode.CLAIMS_NOT_FOUND);
 
-        return token.substring(7);
+        return jwtUtil.parseAccessToken(authorizationHeader);
+    }
+
+    // 토큰 유효성 검증
+    private void validateToken(String token) {
+        jwtUtil.validateToken(token);
+    }
+
+    // 토큰으로 사용자 인증 객체 호출
+    private Authentication getAuthentication(String token) {
+        return jwtUtil.getAuthentication(token);
+    }
+
+    // SecurityContextHolder 사용자 인증 객체 저장
+    private void setAuthentication(Authentication authentication) {
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -24,13 +25,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final String HEADER_PREFIX = "Authorization";
     private final String TOKEN_PREFIX = "Bearer ";
 
-    private final JwtUtil jwtUtil;
+    private final JwtAuthenticationProvider jwtAuthenticationProvider;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             String token = resolveToken(request.getHeader(HEADER_PREFIX));
-            validateToken(token);
             setAuthentication(getAuthentication(token));
         } catch (Exception e) {
             request.setAttribute("exception", e);
@@ -44,20 +44,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (StringUtil.isNullOrEmpty(authorizationHeader) || !authorizationHeader.startsWith(TOKEN_PREFIX))
             throw new CustomException(ErrorCode.CLAIMS_NOT_FOUND);
 
-        return jwtUtil.parseAccessToken(authorizationHeader);
+        return authorizationHeader.substring(TOKEN_PREFIX.length());
     }
 
-    // 토큰 유효성 검증
-    private void validateToken(String token) {
-        jwtUtil.validateToken(token);
-    }
-
-    // 토큰으로 사용자 인증 객체 호출
     private Authentication getAuthentication(String token) {
-        return jwtUtil.getAuthentication(token);
+        return jwtAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken(null, token));
     }
 
-    // SecurityContextHolder 사용자 인증 객체 저장
     private void setAuthentication(Authentication authentication) {
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }

--- a/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final String HEADER_PREFIX = "Authorization";
     private final String TOKEN_PREFIX = "Bearer ";
 
-    private final JwtAuthenticationProvider jwtAuthenticationProvider;
+    private final AuthenticationManager authenticationManager;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -48,7 +49,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private Authentication getAuthentication(String token) {
-        return jwtAuthenticationProvider.authenticate(new UsernamePasswordAuthenticationToken(null, token));
+        return authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(null, token));
     }
 
     private void setAuthentication(Authentication authentication) {

--- a/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationProvider.java
+++ b/src/main/java/com/dongyang/dongpo/util/jwt/JwtAuthenticationProvider.java
@@ -1,0 +1,57 @@
+package com.dongyang.dongpo.util.jwt;
+
+import com.dongyang.dongpo.config.security.CustomUserDetailsService;
+import com.dongyang.dongpo.exception.CustomException;
+import com.dongyang.dongpo.exception.ErrorCode;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationProvider implements AuthenticationProvider {
+
+    private final String ROLE = "role";
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        String token = (String) authentication.getCredentials();
+        jwtUtil.validateToken(token);
+        return getAuthentication(token);
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = jwtUtil.parseClaims(accessToken);
+
+        if (claims == null || claims.get(ROLE) == null)
+            throw new CustomException(ErrorCode.CLAIMS_NOT_FOUND);
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(ROLE).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
+
+        UserDetails principal = customUserDetailsService.loadUserByUsername(claims.getSubject());
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
+    }
+}

--- a/src/main/java/com/dongyang/dongpo/util/jwt/JwtUtil.java
+++ b/src/main/java/com/dongyang/dongpo/util/jwt/JwtUtil.java
@@ -27,28 +27,31 @@ import java.util.Date;
 
 @Slf4j
 @Component
-public class JwtTokenProvider {
+public class JwtUtil {
 
     private final Key key;
     private final long ACCESSTOKEN_VALIDTIME = 30 * 60 * 1000L; // 30분
     private final long REFRESHTOKEN_VALIDTIME = 7 * 24 * 60 * 60 * 1000L; // 7일
+    private final String GRANT_TYPE = "Bearer";
+    private final String ROLE = "role";
+    private final int TOKEN_START = 7;
 
     private final CustomUserDetailsService customUserDetailsService;
     private final TokenBlacklistRepository tokenBlacklistRepository;
 
-    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey, CustomUserDetailsService CustomUserDetailsService, TokenBlacklistRepository tokenBlacklistRepository) {
+    public JwtUtil(@Value("${jwt.secret}") String secretKey, CustomUserDetailsService CustomUserDetailsService, TokenBlacklistRepository tokenBlacklistRepository) {
         byte[] keyBytes = Decoders.BASE64.decode(secretKey);
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.customUserDetailsService = CustomUserDetailsService;
         this.tokenBlacklistRepository = tokenBlacklistRepository;
     }
 
-    public JwtToken createToken(String email, Role role){
+    public JwtToken createToken(String email, Role role) {
         Date now = new Date();
         Date accessTokenExpiredTime = new Date(now.getTime() + ACCESSTOKEN_VALIDTIME);
         Date refreshTokenExpiredTime = new Date(now.getTime() + REFRESHTOKEN_VALIDTIME);
         Claims claims = Jwts.claims().setSubject(email);
-        claims.put("role", role);
+        claims.put(ROLE, role);
 
         String accessToken = Jwts.builder()
                 .setClaims(claims)
@@ -64,30 +67,30 @@ public class JwtTokenProvider {
                 .compact();
 
         return JwtToken.builder()
-                .grantType("Bearer")
+                .grantType(GRANT_TYPE)
                 .claims(email)
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
     }
 
-    public boolean validateToken(String token) throws Exception {
+    public void validateToken(String token) {
+        isBlacklisted(token); // 블랙리스트 등재 여부 확인
         try {
             Jwts.parserBuilder()
                     .setSigningKey(key)
                     .build()
                     .parseClaimsJws(token);
-            return true;
-        } catch (SecurityException | MalformedJwtException | SignatureException e){
+        } catch (SecurityException | MalformedJwtException | SignatureException e) {
             log.error(e.getMessage());
             throw new CustomException(ErrorCode.MALFORMED_TOKEN); // jwt서명이 유효하지 않음
-        } catch (UnsupportedJwtException e){
+        } catch (UnsupportedJwtException e) {
             log.error(e.getMessage());
             throw new CustomException(ErrorCode.UNSUPPORTED_TOKEN); // 지원하지않는 jwt 토큰
-        } catch (ExpiredJwtException e){
+        } catch (ExpiredJwtException e) {
             log.error(e.getMessage());
             throw new CustomException(ErrorCode.EXPIRED_TOKEN); // 토큰 시간 만료
-        } catch (IllegalArgumentException e){
+        } catch (IllegalArgumentException e) {
             log.error(e.getMessage());
             throw new CustomException(ErrorCode.CLAIMS_NOT_FOUND); // claims 없음
         } catch (ClaimJwtException e) {
@@ -96,14 +99,14 @@ public class JwtTokenProvider {
         }
     }
 
-    public Authentication getAuthentication(String accessToken) throws Exception {
+    public Authentication getAuthentication(String accessToken) {
         Claims claims = parseClaims(accessToken);
 
-        if (claims == null || claims.get("role") == null)
+        if (claims == null || claims.get(ROLE) == null)
             throw new CustomException(ErrorCode.CLAIMS_NOT_FOUND);
 
         Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get("role").toString().split(","))
+                Arrays.stream(claims.get(ROLE).toString().split(","))
                         .map(SimpleGrantedAuthority::new)
                         .toList();
 
@@ -125,16 +128,16 @@ public class JwtTokenProvider {
     }
 
     @Transactional
-    public void blacklistToken(String authorization) {
-        tokenBlacklistRepository.save(TokenBlacklist.builder().accessToken(parseAccessToken(authorization)).build());
+    public void blacklistToken(String accessToken) {
+        tokenBlacklistRepository.save(TokenBlacklist.builder().accessToken(parseAccessToken(accessToken)).build());
     }
 
-    public void isBlacklisted(String accessToken) {
+    private void isBlacklisted(String accessToken) {
         if (tokenBlacklistRepository.existsByAccessToken(accessToken))
             throw new CustomException(ErrorCode.EXPIRED_TOKEN);
     }
 
-    public String parseAccessToken(String authorization) {
-        return authorization.substring(7);
+    public String parseAccessToken(String accessToken) {
+        return accessToken.substring(TOKEN_START);
     }
 }

--- a/src/test/java/com/dongyang/dongpo/service/member/MemberServiceTest.java
+++ b/src/test/java/com/dongyang/dongpo/service/member/MemberServiceTest.java
@@ -9,7 +9,7 @@ import com.dongyang.dongpo.repository.member.MemberRepository;
 import com.dongyang.dongpo.repository.member.MemberTitleRepository;
 import com.dongyang.dongpo.service.store.StoreService;
 import com.dongyang.dongpo.service.token.TokenService;
-import com.dongyang.dongpo.util.jwt.JwtTokenProvider;
+import com.dongyang.dongpo.util.jwt.JwtUtil;
 import com.dongyang.dongpo.util.s3.S3Service;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,7 +32,7 @@ class MemberServiceTest {
     private RefreshTokenRepository refreshTokenRepository;
 
     @Mock
-    private JwtTokenProvider jwtTokenProvider;
+    private JwtUtil jwtUtil;
 
     @Mock
     private TokenService tokenService;

--- a/src/test/java/com/dongyang/dongpo/service/token/TokenServiceTest.java
+++ b/src/test/java/com/dongyang/dongpo/service/token/TokenServiceTest.java
@@ -8,7 +8,7 @@ import com.dongyang.dongpo.exception.CustomException;
 import com.dongyang.dongpo.exception.ErrorCode;
 import com.dongyang.dongpo.repository.auth.RefreshTokenRepository;
 import com.dongyang.dongpo.repository.member.MemberRepository;
-import com.dongyang.dongpo.util.jwt.JwtTokenProvider;
+import com.dongyang.dongpo.util.jwt.JwtUtil;
 import io.jsonwebtoken.Claims;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.*;
 class TokenServiceTest {
 
     @Mock
-    private JwtTokenProvider jwtTokenProvider;
+    private JwtUtil jwtUtil;
 
     @Mock
     private RefreshTokenRepository refreshTokenRepository;
@@ -52,10 +52,10 @@ class TokenServiceTest {
         Claims claims = mock(Claims.class);
         claims.setSubject("test@email");
 
-        when(jwtTokenProvider.parseClaims(any())).thenReturn(claims);
+        when(jwtUtil.parseClaims(any())).thenReturn(claims);
         when(refreshTokenRepository.findByRefreshToken(any())).thenReturn(Optional.of(refreshToken));
         when(memberRepository.findByEmail(any())).thenReturn(Optional.of(member));
-        when(jwtTokenProvider.createToken(any(), any())).thenReturn(mockJwtToken);
+        when(jwtUtil.createToken(any(), any())).thenReturn(mockJwtToken);
 
         JwtToken jwtToken = tokenService.reissueAccessToken(jwtTokenReissueDto);
 
@@ -65,7 +65,7 @@ class TokenServiceTest {
 
         verify(refreshTokenRepository).findByRefreshToken(jwtTokenReissueDto.getRefreshToken());
         verify(refreshTokenRepository).save(any(RefreshToken.class));
-        verify(jwtTokenProvider).createToken(member.getEmail(), member.getRole());
+        verify(jwtUtil).createToken(member.getEmail(), member.getRole());
     }
 
 
@@ -94,7 +94,7 @@ class TokenServiceTest {
         JwtTokenReissueDto jwtTokenReissueDto = new JwtTokenReissueDto();
 
         when(refreshTokenRepository.findByRefreshToken(any())).thenReturn(Optional.of(refreshToken));
-        when(jwtTokenProvider.parseClaims(any())).thenReturn(claims);
+        when(jwtUtil.parseClaims(any())).thenReturn(claims);
 
         // Exception
         when(memberRepository.findByEmail(any())).thenReturn(Optional.empty());
@@ -114,7 +114,7 @@ class TokenServiceTest {
         when(member.getEmail()).thenReturn("test@test.com");
         when(member.getRole()).thenReturn(Member.Role.ROLE_MEMBER);
 
-        when(jwtTokenProvider.createToken(member.getEmail(), member.getRole())).thenReturn(mockJwtToken);
+        when(jwtUtil.createToken(member.getEmail(), member.getRole())).thenReturn(mockJwtToken);
         when(refreshTokenRepository.findByEmail(member.getEmail())).thenReturn(Optional.of(refreshToken));
 
         when(mockJwtToken.getAccessToken()).thenReturn("mockAccessToken");


### PR DESCRIPTION
- JwtAuthenticationFilter가 OncePerRequestFilter를 상속받아 각 요청마다 JWT 토큰을 검증하도록 함
- Spring Security의 인증 로직에 맞게 JwtAuthenticationProvider가 AuthenticationProvider를 상속받아 구현
- JwtAuthenticationProvider는 JWT 토큰의 유효성을 검증하고 사용자 정보를 로드함