### PR TITLE
refactor: 예외 응답 포맷 수정

### DIFF
--- a/src/main/java/com/dongyang/dongpo/common/dto/apiresponse/ApiResponse.java
+++ b/src/main/java/com/dongyang/dongpo/common/dto/apiresponse/ApiResponse.java
@@ -1,24 +1,29 @@
 package com.dongyang.dongpo.common.dto.apiresponse;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-@Getter @Setter
-@AllArgsConstructor
-@NoArgsConstructor
+@Getter
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class ApiResponse<T> {
     private T data;
+    private String code;
     private String message;
+
+    public ApiResponse() {}
 
     public ApiResponse(T data) {
         this.data = data;
     }
 
-    public ApiResponse(String message) {
+    public ApiResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public ApiResponse(T data, String code, String message) {
+        this.data = data;
+        this.code = code;
         this.message = message;
     }
 }

--- a/src/main/java/com/dongyang/dongpo/common/exception/CustomControllerAdvice.java
+++ b/src/main/java/com/dongyang/dongpo/common/exception/CustomControllerAdvice.java
@@ -8,14 +8,13 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class CustomControllerAdvice {
-    private static final ApiResponse<String> response = new ApiResponse<>();
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ApiResponse<String>> customException(CustomException e) {
-        response.setMessage(e.getMessage());
-        HttpStatus status = HttpStatus.valueOf(e.getErrorCode().getCode());
+        ErrorCode errorCode = e.getErrorCode();
 
-        return ResponseEntity.status(status).body(response);
+        HttpStatus status = HttpStatus.valueOf(errorCode.getStatus());
+        return ResponseEntity.status(status).body(new ApiResponse<>(errorCode.getCode(), errorCode.getMessage()));
     }
 
 }

--- a/src/main/java/com/dongyang/dongpo/common/exception/ErrorCode.java
+++ b/src/main/java/com/dongyang/dongpo/common/exception/ErrorCode.java
@@ -1,48 +1,47 @@
 package com.dongyang.dongpo.common.exception;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public enum ErrorCode {
+    // 인증 관련 예외
+    SOCIAL_TOKEN_NOT_VALID(401, "A001", "소셜토큰이 유효하지 않습니다."),
+    EXPIRED_TOKEN(401, "A002", "토큰이 만료되었습니다."),
+    HEADER_PARSING_FAILED(401, "A003", "헤더 파싱에 실패하였습니다."),
+    CLAIMS_EXTRACTION_FAILED(401, "A004", "토큰 정보 추출에 실패하였습니다."),
+    CLAIMS_NOT_VALID(401, "A005", "토큰 정보가 유효하지 않습니다."),
+    CLAIMS_NOT_FOUND(401, "A006", "토큰 정보를 찾을 수 없습니다."),
+    UNSUPPORTED_TOKEN(401, "A007", "지원하지 않는 토큰입니다."),
+    MALFORMED_TOKEN(401, "A008", "토큰이 잘못되었습니다."),
+    TOKEN_ISSUER_MISMATCH(401, "A009", "토큰 발급자가 일치하지 않습니다."),
+    TOKEN_AUDIENCE_MISMATCH(401, "A010", "토큰 수신 대상자가 일치하지 않습니다."),
+    UNSUPPORTED_AUTHENTICATION_TYPE(401, "A011", "지원하지 않는 인증 방식입니다."),
+    ADDITIONAL_INFO_REQUIRED_FOR_SIGNUP(401, "A012", "회원 가입에 필요한 추가 정보 요청."),
+    APPLE_AUTHORIZATION_CODE_EXPIRED(401, "A013", "Apple 인증 코드가 만료되었습니다."),
+    APPLE_PUBLIC_KEY_GENERATION_FAILED(401, "A014", "Apple 공개키 생성에 실패하였습니다."),
 
-    MEMBER_NOT_FOUND(404, "회원을 찾지 못하였습니다."),
-    BOOKMARK_NOT_FOUND(404, "북마크를 찾지 못하였습니다."),
-    STORE_NOT_FOUND(404, "점포를 찾지 못하였습니다."),
-    REVIEW_NOT_FOUND(404, "리뷰를 찾기 못하였습니다."),
+    // 사용자 관련 예외
+    MEMBER_NOT_FOUND(400, "B001", "회원을 찾지 못하였습니다."),
+    MEMBER_EMAIL_DUPLICATED(409, "B002", "이미 사용중인 이메일입니다."),
+    MEMBER_ALREADY_EXISTS(409, "B003", "이미 가입된 회원입니다."),
+    MEMBER_ALREADY_LEFT(403, "B004", "탈퇴한 회원입니다."),
+    SERVICE_TERMS_NOT_AGREED(403, "B005", "서비스 이용 약관에 동의 하지 않았습니다."),
 
-    SOCIAL_TOKEN_NOT_VALID(401, "소셜토큰이 유효하지 않습니다."),
-    CLAIMS_NOT_VALID(401, "토큰 정보가 유효하지 않습니다."),
-    CLAIMS_NOT_FOUND(401, "토큰 정보를 찾을 수 없습니다."),
-    EXPIRED_TOKEN(401, "토큰이 만료되었습니다."),
-    UNSUPPORTED_TOKEN(401, "지원하지 않는 토큰입니다."),
-    MALFORMED_TOKEN(401, "토큰이 잘못되었습니다."),
-    TOKEN_ISSUER_MISMATCH(401, "토큰 발급자가 일치하지 않습니다."),
-    TOKEN_AUDIENCE_MISMATCH(401, "토큰 수신 대상자가 일치하지 않습니다."),
-
-    DISTANCE_OUT_OF_RANGE(400, "위치 정보가 오차를 벗어났습니다."),
-    ARGUMENT_NOT_SATISFIED(400, "요청이 잘못되었습니다."),
-    BOOKMARK_ALREADY_EXISTS(400, "해당 점포의 북마크가 이미 존재합니다."),
-	REPORT_REASON_TEXT_REQUIRED(400, "기타 사유는 사유를 작성해야 합니다."),
-    ADDITIONAL_INFO_REQUIRED_FOR_SIGNUP(400, "회원 가입에 필요한 추가 정보 요청."),
-    APPLE_AUTHORIZATION_CODE_EXPIRED(400, "Apple 인증 코드가 만료되었습니다."),
-    APPLE_PUBLIC_KEY_GENERATION_FAILED(400, "Apple 공개키 생성에 실패하였습니다."),
-    HEADER_PARSING_FAILED(400, "헤더 파싱에 실패하였습니다."),
-    CLAIMS_EXTRACTION_FAILED(400, "토큰 정보 추출에 실패하였습니다."),
-    SERVICE_TERMS_NOT_AGREED(400, "서비스 이용 약관에 동의 하지 않았습니다."),
-
-    UNAUTHORIZED(403, "권한이 없습니다."),
-    MEMBER_ALREADY_LEFT(403, "탈퇴한 회원입니다."),
-    UNSUPPORTED_AUTHENTICATION_TYPE(403, "지원하지 않는 인증 방식입니다."),
-
-    MEMBER_EMAIL_DUPLICATED(409, "이미 사용중인 이메일입니다."),
-    MEMBER_ALREADY_EXISTS(409, "이미 가입된 회원입니다."),
+    // 서비스 기능 관련 예외
+    DISTANCE_OUT_OF_RANGE(400, "C001", "위치 정보가 오차를 벗어났습니다."),
+    ARGUMENT_NOT_SATISFIED(400, "C002", "요청이 잘못되었습니다."),
+    BOOKMARK_ALREADY_EXISTS(400, "C003", "해당 점포의 북마크가 이미 존재합니다."),
+    REPORT_REASON_TEXT_REQUIRED(400, "C004", "기타 사유는 사유를 작성해야 합니다."),
+    REVIEW_NOT_OWNED_BY_USER(403, "C005", "사용자가 작성한 리뷰가 아닙니다."),
+    BOOKMARK_NOT_FOUND(400, "C006", "북마크를 찾지 못하였습니다."),
+    STORE_NOT_FOUND(400, "C007", "점포를 찾지 못하였습니다."),
+    REVIEW_NOT_FOUND(400, "C008", "리뷰를 찾지 못하였습니다."),
     ;
 
-    private final int code;
+    private final int status;
+    private final String code;
     private final String message;
 
-    ErrorCode(int code, String message) {
-        this.code = code;
-        this.message = message;
-    }
 }

--- a/src/main/java/com/dongyang/dongpo/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dongyang/dongpo/domain/auth/controller/AuthController.java
@@ -40,9 +40,13 @@ public class AuthController {
     public ResponseEntity<ApiResponse<?>> apple(@RequestBody AppleLoginDto appleLoginDto) {
         AppleLoginResponse response = authService.handleAppleLogin(appleLoginDto);
 
-        return response.getJwtToken() == null
-                ? ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(new ApiResponse<>(response.getClaims(), ErrorCode.ADDITIONAL_INFO_REQUIRED_FOR_SIGNUP.toString()))
-                : ResponseEntity.ok(new ApiResponse<>(response.getJwtToken()));
+        return response.getJwtToken() == null ?
+                ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(
+                        new ApiResponse<>(
+                                response.getClaims(),
+                                ErrorCode.ADDITIONAL_INFO_REQUIRED_FOR_SIGNUP.getCode(),
+                                ErrorCode.ADDITIONAL_INFO_REQUIRED_FOR_SIGNUP.getMessage())
+                ) : ResponseEntity.ok(new ApiResponse<>(response.getJwtToken()));
     }
 
     @PostMapping("/apple/continue")

--- a/src/main/java/com/dongyang/dongpo/domain/store/service/StoreReviewService.java
+++ b/src/main/java/com/dongyang/dongpo/domain/store/service/StoreReviewService.java
@@ -97,7 +97,7 @@ public class StoreReviewService {
         Member reviewMember = review.getMember();
 
         if (!reviewMember.getId().equals(member.getId()))
-            throw new CustomException(ErrorCode.UNAUTHORIZED);
+            throw new CustomException(ErrorCode.REVIEW_NOT_OWNED_BY_USER);
 
         review.delete();
         log.info("Deleted Review: {} by Member: {}", reviewId, member.getEmail());


### PR DESCRIPTION
- 서비스 자체 Error Code를 도입하여 예외 상태를 더 세부적으로 구분하도록 한다

ex.
```json
// HTTP 401
{
  "code": "A002",
  "message": "토큰이 만료되었습니다."
}
```